### PR TITLE
Add js extension to import paths

### DIFF
--- a/packages/generator/src/lib/syntaxes/imports.ts
+++ b/packages/generator/src/lib/syntaxes/imports.ts
@@ -4,7 +4,7 @@ export function namedImport(names: string[], path: string) {
 		names: names,
 		module: path,
 		render() {
-			return `import { ${names.join(', ')} } from '${path}';`
+			return `import { ${names.join(', ')} } from '${renderImportPath(path)}';`
 		},
 	}
 }
@@ -16,7 +16,7 @@ export function defaultImportValue(name: string, path: string) {
 		name,
 		module: path,
 		render() {
-			return `import ${name} from '${path}';`
+			return `import ${name} from '${renderImportPath(path)}';`
 		},
 	}
 }
@@ -26,7 +26,7 @@ export function wildcardImport(alias: string, path: string) {
 		type: 'wildcardImport' as const,
 		module: path,
 		render() {
-			return `import * as ${alias} from '${path}';`
+			return `import * as ${alias} from '${renderImportPath(path)}';`
 		},
 	}
 }
@@ -35,3 +35,10 @@ export type ImportValue =
 	| NamedImport
 	| ReturnType<typeof defaultImportValue>
 	| ReturnType<typeof wildcardImport>
+
+/**
+ * Adds the .js extension to relative imports.
+ */
+function renderImportPath(path: string) {
+  return path.startsWith(".") ? `${path}.js` : path;
+}


### PR DESCRIPTION
This PR adds the `.js` extension to relative imports. This is required when the `moduleResolution` is `NodeNext`. However, I believe this is harmless otherwise. So the simplest solution may be to just always add the extension to relative imports. I could be wrong though. I did not test other configuration.

If you want to use this branch as a temporary workaround you can istall it using

```
yarn add daniel-nagy/prisma-generator-drizzle#js-ext-pkg
```

or a similar git URL if you're not using yarn.

resolves #18 