### PR TITLE
feat: verbatimModuleSyntax

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,17 @@
+services:
+  postgres:
+    image: postgres:latest
+    container_name: prisma-generator-drizzle-postgres
+    environment:
+      - POSTGRES_USER=postgres
+      - POSTGRES_PASSWORD=postgres
+      - POSTGRES_DB=generator
+    ports:
+      - "5432:5432"
+  mysql:
+    image: mysql
+    environment:
+      MYSQL_ROOT_PASSWORD: mysql
+      MYSQL_DATABASE: generator
+    ports:
+      - "3306:3306"

--- a/packages/generator/src/lib/adapter/fields/createField.ts
+++ b/packages/generator/src/lib/adapter/fields/createField.ts
@@ -69,8 +69,9 @@ function getCustomType(field: DMMF.Field) {
 		throw new Error(`Invalid type definition: ${field.documentation}`)
 
 	const [module, type] = splits
+
 	return {
-		imports: namedImport([type], module),
+		imports: namedImport([type], module, true),
 		code: `.$type<${type}>()`,
 	}
 }

--- a/packages/generator/src/lib/config.ts
+++ b/packages/generator/src/lib/config.ts
@@ -7,6 +7,9 @@ import {
 	optional,
 	safeParse,
 	string,
+	union,
+	literal,
+	transform,
 } from 'valibot'
 import { DateMode } from '~/shared/date-mode'
 import { ModuleResolution } from '~/shared/generator-context/module-resolution'
@@ -15,6 +18,7 @@ import { BooleanInStr, withDefault } from './valibot-schema'
 const Config = object({
 	relationalQuery: withDefault(optional(BooleanInStr), true),
 	moduleResolution: optional(ModuleResolution),
+	verbatimModuleSyntax: transform(optional(union([literal('true'), literal('false')])), val => val === 'true'),
 	verbose: optional(BooleanInStr),
 	formatter: optional(string()),
 	dateMode: optional(DateMode),

--- a/packages/generator/src/lib/syntaxes/imports.ts
+++ b/packages/generator/src/lib/syntaxes/imports.ts
@@ -1,23 +1,31 @@
-import { getModuleResolution } from '~/shared/generator-context'
+import { getModuleResolution, getVerbatimModuleSyntax } from '~/shared/generator-context'
 
-export function namedImport(names: string[], path: string) {
+export function namedImport(names: string[], path: string, handleVerbatimModuleSyntax = false) {
 	return {
 		type: 'namedImport' as const,
 		names: names,
 		module: path,
+		handleVerbatimModuleSyntax,
 		render() {
+			if (this.handleVerbatimModuleSyntax && getVerbatimModuleSyntax()) {
+				return `import { type ${names.join(', type ')} } from '${path}';`
+			}
+
 			return `import { ${names.join(', ')} } from '${renderImportPath(path)}';`
 		},
 	}
 }
 export type NamedImport = ReturnType<typeof namedImport>
 
-export function defaultImportValue(name: string, path: string) {
+export function defaultImportValue(name: string, path: string, handleVerbatimModuleSyntax = false) {
 	return {
 		type: 'defaultImport' as const,
 		name,
 		module: path,
 		render() {
+			if (handleVerbatimModuleSyntax && getVerbatimModuleSyntax()) {
+				return `import type ${name} from '${path}';`
+			}
 			return `import ${name} from '${renderImportPath(path)}';`
 		},
 	}

--- a/packages/generator/src/shared/generator-context/index.ts
+++ b/packages/generator/src/shared/generator-context/index.ts
@@ -70,3 +70,7 @@ export function isRelationalQueryEnabled() {
 export function getModuleResolution() {
 	return getGenerator().config.moduleResolution
 }
+
+export function getVerbatimModuleSyntax() {
+	return getGenerator().config.verbatimModuleSyntax
+}

--- a/packages/usage/prisma/types.ts
+++ b/packages/usage/prisma/types.ts
@@ -1,0 +1,4 @@
+export type Attachment = {
+    name: string;
+    something: string;
+}


### PR DESCRIPTION
Hi, i was feeling bad for opening up yet another issue so i gave it a try by myself.

However, i got stuck. In this part of code

```typescript
if (this.handleVerbatimModuleSyntax && getVerbatimModuleSyntax()) {
  return `import { type ${names.join(', type ')} } from '${path}';`
}

return `import { ${names.join(', ')} } from '${renderImportPath(path)}';`
```

Regardless of what i tried, the `this.handleVerbatimModuleSyntax` is always `false`. It's like the `this` is overriden. I have tracked it down to `this` 

https://github.com/farreldarian/prisma-generator-drizzle/blob/5d64493c0d1ab5aa720e1856983d0f8e3d5cc942/packages/generator/src/generator.ts#L136

In that part the `this` is somehow overriden and the `handleVerbatimModuleSyntax` becomes `false`