### PR TITLE
fix: json list was not generating type as array

### DIFF
--- a/packages/generator/src/lib/adapter/fields/createField.ts
+++ b/packages/generator/src/lib/adapter/fields/createField.ts
@@ -71,7 +71,7 @@ function getCustomType(field: DMMF.Field) {
 	const [module, type] = splits
 	return {
 		imports: namedImport([type], module),
-		code: `.$type<${type}>()`,
+		code: `.$type<${type}${field.isList ? '[]' : ''}>()`,
 	}
 }
 

--- a/packages/usage/prisma/custom-types.ts
+++ b/packages/usage/prisma/custom-types.ts
@@ -1,0 +1,3 @@
+export type CustomJson = {
+    foo: string
+}

--- a/packages/usage/prisma/schema.prisma
+++ b/packages/usage/prisma/schema.prisma
@@ -125,6 +125,8 @@ model Field {
   stringList String[] // -mysql -sqlite
   bytes      Bytes?
   json       Json? // -sqlite
+  /// drizzle.type ../custom-types::CustomJson
+  cusomJsonList   Json[] // -sqlite
   enum       Enum? // -sqlite
 }
 

--- a/packages/usage/prisma/schema.prisma
+++ b/packages/usage/prisma/schema.prisma
@@ -126,7 +126,7 @@ model Field {
   bytes      Bytes?
   json       Json? // -sqlite
   /// drizzle.type ../custom-types::CustomJson
-  cusomJsonList   Json[] // -sqlite
+  cusomJsonList   Json[] // -sqlite -mysql
   enum       Enum? // -sqlite
 }
 

--- a/packages/usage/tests/shared/testFields.ts
+++ b/packages/usage/tests/shared/testFields.ts
@@ -22,12 +22,12 @@ export function testFields({ db, schema, provider }: TestContext) {
 		let data = input as Return
 
 		if (provider === 'sqlite') {
-			const { enum: _, json, stringList, ...rest } = data
+			const { enum: _, json, stringList, cusomJsonList, ...rest } = data
 			data = rest as Return
 		}
 
 		if (provider === 'mysql') {
-			const { stringList, ...rest } = data
+			const { stringList, cusomJsonList, ...rest } = data
 			data = rest as Return
 		}
 
@@ -51,6 +51,7 @@ export function testFields({ db, schema, provider }: TestContext) {
 				bytes: Buffer.from('hello world'),
 				enum: 'A',
 				stringList: ['John', 'Doe'],
+				cusomJsonList: [{ foo: "bar" }]
 			})
 			// --
 
@@ -75,6 +76,9 @@ export function testFields({ db, schema, provider }: TestContext) {
 				boolean: true,
 				float: 0.123,
 				stringList: [],
+				cusomJsonList: [
+					{ foo: "bar" },
+				]
 			})
 			// --
 


### PR DESCRIPTION
This PR should add support for json list. Not sure if that's 100% correct but in my codebase i have to explicitly set the type as array even though drizzle knows it's array