### PR TITLE
fix: picklist was validated after coerce to boolean

### DIFF
--- a/packages/generator/src/lib/valibot-schema.ts
+++ b/packages/generator/src/lib/valibot-schema.ts
@@ -1,4 +1,4 @@
-import { coerce, literal, union } from 'valibot'
+import { coerce, picklist } from 'valibot'
 import {
 	type BaseSchema,
 	type OptionalSchema,
@@ -14,9 +14,9 @@ export function withDefault<Schema extends OptionalSchema<BaseSchema>>(
 }
 
 export const BooleanInStr = transform(
-	coerce(union([literal('true'), literal('false')]), (value) => {
+	coerce(picklist(['true', 'false']), (value) => {
 		if (typeof value !== 'string') return value
-		return value.toLowerCase() === 'true'
+		return value.toLowerCase()
 	}),
 	(value) => value === 'true'
 )


### PR DESCRIPTION
This PR slightly improves using the api from `union([literal(), literal()])` because unions are usually used when parsing different data types into `picklist`.

It also fixes the usage of using true | false values.

At least on my machine, values that are boolean (eg. verbose) were not parsed correctly and always threw an error saying that it expected 'true' | 'false' but got false.

I figured that it was because in `coerce` method, the callback is executed first and then the validation happens. Which means that it was coerced to boolean and then it was trying to validate two literals which always failed.