### PR TITLE
Feat/allow format to fail

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ In addition to the Prisma features, you can also generate Drizzle-specific featu
 | relationalQuery | Flag to generate relational query | true        | false       |
 | moduleResolution         | Specify the [module resolution](https://www.typescriptlang.org/tsconfig#moduleResolution) that will affect the import style | _*auto_           | nodenext        |
 | verbose         | Flag to enable verbose logging    | -           | true        |
+| abortOnFailedFormatting | Flag to throw exception when formatting fails | true | false |
 | **dateMode | Change the generated mode for date | "date" ||
 
 _* It will find the closest tsconfig from the current working directory. Note that [extends](https://www.typescriptlang.org/tsconfig#extends) is not supported_

--- a/packages/generator/src/generator.ts
+++ b/packages/generator/src/generator.ts
@@ -85,21 +85,30 @@ generatorHandler({
 function handleFormatting() {
 	const generator = getGenerator()
 	if (generator.config.formatter == null) return
-	switch (generator.config.formatter) {
-		case 'prettier':
-			execSync(`prettier --write ${generator.output.path}`, {
-				stdio: 'inherit',
-			})
-			break
-		case 'biome':
-			execSync(`biome format --write ${generator.output.path}`, {
-				stdio: 'inherit',
-			})
-			break
-		default:
-			execSync(`${generator.config.formatter} ${generator.output.path}`, {
-				stdio: 'inherit',
-			})
+
+	try {
+		switch (generator.config.formatter) {
+			case 'prettier':
+				execSync(`prettier --write ${generator.output.path}`, {
+					stdio: 'inherit',
+				})
+				break
+			case 'biome':
+				execSync(`biome format --write ${generator.output.path}`, {
+					stdio: 'inherit',
+				})
+				break
+			default:
+				execSync(`${generator.config.formatter} ${generator.output.path}`, {
+					stdio: 'inherit',
+				})
+		}
+	} catch (e) {
+		if (generator.config.abortOnFailedFormatting) {
+			throw e
+		}
+
+		logger.log('Failed to format the generated schema')
 	}
 }
 

--- a/packages/generator/src/lib/config.ts
+++ b/packages/generator/src/lib/config.ts
@@ -17,6 +17,7 @@ const Config = object({
 	moduleResolution: optional(ModuleResolution),
 	verbose: optional(BooleanInStr),
 	formatter: optional(string()),
+	abortOnFailedFormatting: withDefault(optional(BooleanInStr), true),
 	dateMode: optional(DateMode),
 })
 export type Config = Output<typeof Config>

--- a/packages/generator/src/lib/valibot-schema.ts
+++ b/packages/generator/src/lib/valibot-schema.ts
@@ -1,4 +1,4 @@
-import { coerce, literal, union } from 'valibot'
+import { coerce, picklist } from 'valibot'
 import {
 	type BaseSchema,
 	type OptionalSchema,
@@ -14,9 +14,9 @@ export function withDefault<Schema extends OptionalSchema<BaseSchema>>(
 }
 
 export const BooleanInStr = transform(
-	coerce(union([literal('true'), literal('false')]), (value) => {
+	coerce(picklist(['true', 'false']), (value) => {
 		if (typeof value !== 'string') return value
-		return value.toLowerCase() === 'true'
+		return value.toLowerCase()
 	}),
 	(value) => value === 'true'
 )


### PR DESCRIPTION
If this PR is accepted, it must be merged **after** #61.

This is just a safety mechanism for edge cases. I deploy my application on Render.com. During the pipeline, prisma generation happens and it complains that `GLIB_C 2.29 not found`. Since biome is written in rust, it uses some of the native libraries and this one is not available.

Unless you deploy using docker, you have no control over the system packages installed in Render and since it happened to me, it can happen to anyone else 😅

So that's why I'm proposing this feature. If you don't feel comfortable with this, feel free to close it.

The default value is set to true to not introduce breaking change